### PR TITLE
Add memoization of dihedral_pairs instead of computing them each iteration

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -159,7 +159,7 @@ class GeoMol(nn.Module):
 
         self.neighbors = get_neighbor_ids(data)
         self.leaf_hydrogens = get_leaf_hydrogens(self.neighbors, x)
-        self.dihedral_pairs = get_dihedral_pairs(edge_index, self.neighbors, data)
+        self.dihedral_pairs = data.edge_index_dihedral_pairs
 
         self.n_neighborhoods = len(self.neighbors)
         self.n_dihedral_pairs = len(self.dihedral_pairs.t())

--- a/model/utils.py
+++ b/model/utils.py
@@ -71,7 +71,7 @@ def get_leaf_hydrogens(neighbors, x):
     return leaf_hydrogens
 
 
-def get_dihedral_pairs(edge_index, neighbors, data):
+def get_dihedral_pairs(edge_index, data):
     """
     Given edge indices, return pairs of indices that we must calculate dihedrals for
     """


### PR DESCRIPTION
Add memoization of dihedral_pairs in datasets such that they are only computed in the first epoch and then stored in memory and reused. This should speed up the code since computing the dihedral pairs previously took up 73% of the runtime in my experiments. Now, this overhead will only happen in the first epoch, and the additional memory usage is negligible.

Calling the attribute of the PyTorch geometric Data object edge_index_dihedral_pairs has the dihedral_pairs being treated as edge indices during batching such that PyTorch geometric automatically takes care of increasing the indices of the dihedral_pairs according to the graph sizes when creating a batch.